### PR TITLE
[add] Heading 컴포넌트 스타일링 및 기능 구현, RootLayout 추가

### DIFF
--- a/src/components/Heading.jsx
+++ b/src/components/Heading.jsx
@@ -1,0 +1,95 @@
+import { arrowLeft } from '@/assets/icons/svg-icons.js';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useEffect, useState } from 'react';
+
+function Heading() {
+  const { pathname } = useLocation();
+  const navigate = useNavigate();
+  const [title, setTitle] = useState('');
+
+  useEffect(
+    () => (pathname === '/signup' ? setTitle('회원가입') : undefined),
+    [pathname]
+  );
+
+  useEffect(
+    () => (pathname === '/home' ? setTitle('메뉴 찾기') : undefined),
+    [pathname]
+  );
+
+  useEffect(
+    () =>
+      pathname === '/fridgemenu'
+        ? setTitle('내 냉장고를 비워줄 메뉴')
+        : undefined,
+    [pathname]
+  );
+
+  useEffect(
+    () => (pathname === '/myprofile' ? setTitle('프로필') : undefined),
+    [pathname]
+  );
+
+  useEffect(
+    () =>
+      pathname === '/addingredients'
+        ? setTitle('내 냉장고 재료 추가하기')
+        : undefined,
+    [pathname]
+  );
+
+  useEffect(
+    () =>
+      pathname === '/recipeliked' ? setTitle('좋아요 누른 레시피') : undefined,
+    [pathname]
+  );
+
+  useEffect(
+    () => (pathname === '/myfridge' ? setTitle('내 냉장고') : undefined),
+    [pathname]
+  );
+
+  useEffect(
+    () => (pathname === '/menulist' ? setTitle('오늘 뭐먹지?') : undefined),
+    [pathname]
+  );
+
+  useEffect(
+    () => (pathname === '/recipedetail' ? setTitle('마라샹궈') : undefined),
+    [pathname]
+  );
+
+  useEffect(
+    () => (pathname === '/search' ? setTitle('') : undefined),
+    [pathname]
+  );
+
+  useEffect(
+    () => (pathname === '/searchresult' ? setTitle('') : undefined),
+    [pathname]
+  );
+
+  if (pathname === '/' || pathname === '/signin') {
+    return null;
+  }
+
+  return (
+    <>
+      <div className="wrapper max-w-[820px] m-auto relative pt-[20px] flex justify-center items-center">
+        <div className="container flex justify-center items-center">
+          <button
+            className="w-[20px] h-[20px] absolute left-[20px] top-[25px]"
+            onClick={() => navigate(-1)}
+          >
+            <img className="w-full h-full" src={arrowLeft} alt="뒤로가기" />
+          </button>
+          <h1 className="font-dohyeon -text--fridge-black text-[20px]">
+            {title}
+          </h1>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export default Heading;

--- a/src/layout/RootLayout.jsx
+++ b/src/layout/RootLayout.jsx
@@ -1,13 +1,15 @@
 import NavBar from '@/components/navBar/NavBar';
+import Heading from '@/components/Heading';
 import { Outlet } from 'react-router-dom';
 
 export default function RootLayout() {
   return (
     <>
+      <Heading />
       <main>
         <Outlet />
       </main>
-      <NavBar/>
+      <NavBar />
     </>
   );
 }


### PR DESCRIPTION
### 1. 스타일링 및 기능 구현 완료
- UI 구현 완료
- 페이지별 다른 heading 적용 완료 (heading 없음, 제목 없음, heading 및 제목 있음)
- 뒤로가기 버튼 기능 구현 완료

### 2. 미구현 기능
- menulist 페이지에서 클릭한 메뉴를 recipedetail 의 heading 에서 랜더링하는 기능 (menulist 페이지 구현 이후 추가되어야 함)

---
![스크린샷 2023-09-12 오후 2 26 54](https://github.com/FRONTENDSCHOOL6/5lemental-final/assets/134567470/3999059e-cbb6-401c-af26-24ad2eb889e9)
![스크린샷 2023-09-12 오후 2 23 21](https://github.com/FRONTENDSCHOOL6/5lemental-final/assets/134567470/8541f4fe-6b40-4ecd-b81c-768f6c05abdd)

![스크린샷 2023-09-12 오후 2 23 39](https://github.com/FRONTENDSCHOOL6/5lemental-final/assets/134567470/fd505420-9d56-4b35-b419-be30c96d92a3)
