### PR TITLE
[delete] searchResult 페이지 제거

### DIFF
--- a/src/pages/SearchResult.jsx
+++ b/src/pages/SearchResult.jsx
@@ -1,5 +1,0 @@
-function SearchResult () {
-
-}
-
-export default SearchResult

--- a/src/routes.jsx
+++ b/src/routes.jsx
@@ -12,7 +12,6 @@ import MyProfile from './pages/MyProfile';
 import RecipeDetail from './pages/RecipeDetail';
 import RecipeLiked from './pages/RecipeLiked';
 import Search from './pages/Search';
-import SearchResult from './pages/SearchResult';
 import SignUp from './pages/SignUp';
 import Start from './pages/Start';
 
@@ -30,7 +29,6 @@ const router = createBrowserRouter(
         <Route path="recipedetail" element={<RecipeDetail />} />
         <Route path="recipeliked" element={<RecipeLiked />} />
         <Route path="search" element={<Search />} />
-        <Route path="searchresult" element={<SearchResult />} />
         <Route path="signin" element={<SignIn />} />
         <Route path="signup" element={<SignUp />} />
       </Route>


### PR DESCRIPTION
![image](https://github.com/FRONTENDSCHOOL6/5lemental-final/assets/134567479/4a61280a-5430-4311-82d3-4d478246bf5f)

두 페이지의 분리가 불필요하다는 회의 결과에 따라 searchResult 페이지 삭제, Routes.jsx 안의 코드 제거