### PR TITLE
[add] SignIn 페이지 로그인실패 toast 기능 추가, MyProfile 페이지 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "react-helmet-async": "1.3.0",
     "react-hot-toast": "2.4.1",
     "react-router-dom": "6.15.0",
+    "react-toastify": "^9.1.3",
     "zustand": "4.4.1"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   react-router-dom:
     specifier: 6.15.0
     version: 6.15.0(react-dom@18.2.0)(react@18.2.0)
+  react-toastify:
+    specifier: ^9.1.3
+    version: 9.1.3(react-dom@18.2.0)(react@18.2.0)
   zustand:
     specifier: 4.4.1
     version: 4.4.1(@types/react@18.2.15)(immer@10.0.2)(react@18.2.0)
@@ -1165,6 +1168,11 @@ packages:
     dependencies:
       mimic-response: 1.0.1
     dev: true
+
+  /clsx@1.2.1:
+    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
+    dev: false
 
   /color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -3490,6 +3498,17 @@ packages:
     dependencies:
       '@remix-run/router': 1.8.0
       react: 18.2.0
+    dev: false
+
+  /react-toastify@9.1.3(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==}
+    peerDependencies:
+      react: '>=16'
+      react-dom: '>=16'
+    dependencies:
+      clsx: 1.2.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /react@18.2.0:

--- a/src/api/pocketbase.jsx
+++ b/src/api/pocketbase.jsx
@@ -2,4 +2,8 @@ import PocketBase from 'pocketbase';
 
 const pb = new PocketBase(import.meta.env.VITE_PH_URL);
 
+if (import.meta.env.DEV) {
+  pb.autoCancellation(false);
+}
+
 export default pb;

--- a/src/components/button/Button.jsx
+++ b/src/components/button/Button.jsx
@@ -9,7 +9,9 @@ export function Button({
 }) {
   const navigate = useNavigate();
   const handleNavigate = () => {
-    navigate({ navigateTo });
+    navigate(navigateTo);
+    console.log(navigateTo);
+    console.log('haha');
   };
   return (
     <button

--- a/src/components/button/Button.jsx
+++ b/src/components/button/Button.jsx
@@ -8,11 +8,13 @@ export function Button({
   ...restProps
 }) {
   const navigate = useNavigate();
+
   const handleNavigate = () => {
-    navigate(navigateTo);
-    console.log(navigateTo);
-    console.log('haha');
+    if (type === 'button') {
+      navigate(navigateTo);
+    }
   };
+
   return (
     <button
       type={type}

--- a/src/components/button/Button.module.css
+++ b/src/components/button/Button.module.css
@@ -3,5 +3,5 @@ button.large {
 }
 
 button.small {
-  @apply -bg--fridge-primary -text--fridge-white font-dohyeon w-[204px] h-[40px] rounded-[15px] text-[20px] mt-[30px];
+  @apply -bg--fridge-primary -text--fridge-white font-dohyeon w-[204px] h-[40px] rounded-[15px] text-[18px] mt-[13px];
 }

--- a/src/components/categoryButton/CategoryButton.jsx
+++ b/src/components/categoryButton/CategoryButton.jsx
@@ -1,11 +1,23 @@
-import { useState } from 'react';
+import pb from '@/api/pocketbase';
 import S from './CategoryButton.module.css';
+import { useState } from 'react';
 
 function CategoryButton() {
   const [selected, setSelected] = useState('');
 
   const handleSelect = (category) => {
     setSelected(category);
+  };
+
+  const handleCategory = async (menu) => {
+    try {
+      const response = await pb
+        .collection('cooks')
+        .getList(1, 10, { filter: `category = "${menu}"` });
+      response.items.map((item) => console.log(item.name));
+    } catch (error) {
+      console.error(error);
+    }
   };
 
   return (
@@ -15,6 +27,7 @@ function CategoryButton() {
           <button
             onClick={() => {
               handleSelect('korean');
+              handleCategory('한식');
             }}
             className={selected === 'korean' ? S.selected : S.notSelected}
           >
@@ -23,6 +36,7 @@ function CategoryButton() {
           <button
             onClick={() => {
               handleSelect('japanese');
+              handleCategory('일식');
             }}
             className={selected === 'japanese' ? S.selected : S.notSelected}
           >
@@ -31,6 +45,7 @@ function CategoryButton() {
           <button
             onClick={() => {
               handleSelect('chinese');
+              handleCategory('중식');
             }}
             className={selected === 'chinese' ? S.selected : S.notSelected}
           >
@@ -39,6 +54,7 @@ function CategoryButton() {
           <button
             onClick={() => {
               handleSelect('western');
+              handleCategory('양식');
             }}
             className={selected === 'western' ? S.selected : S.notSelected}
           >

--- a/src/pages/MyProfile.jsx
+++ b/src/pages/MyProfile.jsx
@@ -67,6 +67,7 @@ function MyProfile() {
         <ToastContainer
           position="top-center"
           autoClose={3000}
+          limit={1}
           hideProgressBar={false}
           newestOnTop={false}
           closeOnClick

--- a/src/pages/MyProfile.jsx
+++ b/src/pages/MyProfile.jsx
@@ -1,7 +1,8 @@
-// import pb from '@/api/pocketbase';
+import pb from '@/api/pocketbase';
 import { Button } from '@/components/button/Button';
 import { useNavigate } from 'react-router-dom';
-// import { useState } from 'react';
+import { useState } from 'react';
+import { useEffect } from 'react';
 
 function MyProfile() {
   const navigate = useNavigate();
@@ -9,22 +10,57 @@ function MyProfile() {
     navigate('/myfridge');
   };
 
+  const [profileName, setProfileName] = useState('');
+  const [fileName, setFileName] = useState('');
+  const [profileImage, setProfileImage] = useState('');
+
+  useEffect(() => {
+    const handleProfile = async () => {
+      try {
+        // PocketBase 에서 닉네임 가져오기
+        const nameResponse = await pb
+          .collection('users')
+          .getList(1, 10, { filter: `username = "qwer1212"` });
+        setProfileName(nameResponse.items[0].name);
+        console.log(profileName);
+
+        // PocketBase 에서 프로필 이미지 가져오기
+        const imageResponse = await pb
+          .collection('users')
+          .getList(1, 10, { filter: `username = "qwer1212"` });
+        setFileName(imageResponse.items[0].avatar);
+        setProfileImage(
+          pb.files.getUrl(imageResponse.items[0], fileName, {
+            thumb: '80x80',
+          })
+        );
+        console.log(profileImage);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    handleProfile();
+  }, [profileName, profileImage, fileName]);
+
   return (
     <>
       <div className="wapper w-screen px-[26px] pt-[25px] -bg--fridge-white flex flex-nowrap flex-col">
         <div className="container max-w-[400px] mx-auto flex flex-nowrap flex-col">
-          <div className="topFridge bg-[#F5F5F5] rounded-t-[15px] mb-[15px] min-h-[123px] px-[22px] py-4 flex flex-nowrap justify-center items-center gap-[25px]">
-            <div className="profileImage">
-              <img src="/" alt="프로필" className="profile" />
-            </div>
+          <div className="topFridge bg-[#F5F5F5] rounded-t-[15px] mb-[15px] min-h-[123px] px-[22px] py-4 flex flex-nowrap justify-center items-center gap-[20px]">
+            <img
+              src={profileImage}
+              alt="프로필"
+              className="w-[80px] h-[80px] rounded-[10px]"
+            />
+
             <div className="profileGreetings">
               <p className="font-nanum text-sm">
-                <span className="font-bold mr-2">김감자</span>님,
+                <span className="font-bold mr-2">{profileName}</span>님,
               </p>
               <p className="text-xs">오늘도 즐거운 식사하세요!</p>
               <button
                 onClick={handleNavigate}
-                className="openFridge -bg--fridge-primary -text--fridge-white font-dohyeon rounded-[5px] text-[14px] pt-[7px] pb-[5px] px-[14px] mt-[13px]"
+                className="openFridge -bg--fridge-primary -text--fridge-white font-dohyeon rounded-[5px] text-[12px] pt-[7px] pb-[5px] px-[10px] mt-[13px]"
               >
                 내 냉장고 열어보기
               </button>

--- a/src/pages/MyProfile.jsx
+++ b/src/pages/MyProfile.jsx
@@ -1,5 +1,53 @@
-function MyProfile () {
+// import pb from '@/api/pocketbase';
+import { Button } from '@/components/button/Button';
+import { useNavigate } from 'react-router-dom';
+// import { useState } from 'react';
 
+function MyProfile() {
+  const navigate = useNavigate();
+  const handleNavigate = () => {
+    navigate('/myfridge');
+  };
+
+  return (
+    <>
+      <div className="wapper w-screen px-[26px] pt-[25px] -bg--fridge-white flex flex-nowrap flex-col">
+        <div className="container max-w-[400px] mx-auto flex flex-nowrap flex-col">
+          <div className="topFridge bg-[#F5F5F5] rounded-t-[15px] mb-[15px] min-h-[123px] px-[22px] py-4 flex flex-nowrap justify-center items-center gap-[25px]">
+            <div className="profileImage">
+              <img src="/" alt="프로필" className="profile" />
+            </div>
+            <div className="profileGreetings">
+              <p className="font-nanum text-sm">
+                <span className="font-bold mr-2">김감자</span>님,
+              </p>
+              <p className="text-xs">오늘도 즐거운 식사하세요!</p>
+              <button
+                onClick={handleNavigate}
+                className="openFridge -bg--fridge-primary -text--fridge-white font-dohyeon rounded-[5px] text-[14px] pt-[7px] pb-[5px] px-[14px] mt-[13px]"
+              >
+                내 냉장고 열어보기
+              </button>
+            </div>
+          </div>
+          <div className="bottomFridge bg-[#F5F5F5] rounded-b-[15px] h-[268px] relative px-auto pt-[125px] pb-[55px]">
+            <div className="FridgeHandle w-[14px] h-[75px] -bg--fridge-gray rounded-[15px] absolute top-[20px] right-[24px]"></div>
+            <div className="buttonGroup flex flex-col items-center">
+              <Button type="button" navigateTo="/recipeliked" small>
+                좋아요 한 음식
+              </Button>
+              <Button type="button" small>
+                랜덤메뉴
+              </Button>
+            </div>
+          </div>
+          <button className="logOut text-right text-[10px] font-nanum mt-1 mr-1 decoration-solid underline">
+            로그아웃
+          </button>
+        </div>
+      </div>
+    </>
+  );
 }
 
-export default MyProfile
+export default MyProfile;

--- a/src/pages/MyProfile.jsx
+++ b/src/pages/MyProfile.jsx
@@ -4,9 +4,11 @@ import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { useEffect } from 'react';
 import useAuthStore from '@/store/auth';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 function MyProfile() {
-  const user = useAuthStore((state) => state.user);
+  const { user, signOut } = useAuthStore();
   console.log(user);
   const navigate = useNavigate();
   const handleNavigate = () => {
@@ -16,6 +18,20 @@ function MyProfile() {
   const [profileName, setProfileName] = useState('');
   const [fileName, setFileName] = useState('');
   const [profileImage, setProfileImage] = useState('');
+
+  const handleSignOut = async (e) => {
+    e.preventDefault();
+    try {
+      await signOut().then(() => {
+        toast.info('로그아웃 되었습니다.');
+        setTimeout(() => {
+          navigate('/signin');
+        }, 3000);
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  };
 
   useEffect(() => {
     const handleProfile = async () => {
@@ -48,6 +64,18 @@ function MyProfile() {
   return (
     <>
       <div className="wapper w-screen px-[26px] pt-[25px] -bg--fridge-white flex flex-nowrap flex-col">
+        <ToastContainer
+          position="top-center"
+          autoClose={3000}
+          hideProgressBar={false}
+          newestOnTop={false}
+          closeOnClick
+          rtl={false}
+          pauseOnFocusLoss
+          draggable
+          pauseOnHover
+          theme="colored"
+        />
         <div className="container max-w-[400px] mx-auto flex flex-nowrap flex-col">
           <div className="topFridge bg-[#F5F5F5] rounded-t-[15px] mb-[15px] min-h-[123px] px-[22px] py-4 flex flex-nowrap justify-center items-center gap-[20px]">
             <img
@@ -80,7 +108,10 @@ function MyProfile() {
               </Button>
             </div>
           </div>
-          <button className="logOut text-right text-[10px] font-nanum mt-1 mr-1 decoration-solid underline">
+          <button
+            onClick={handleSignOut}
+            className="logOut text-right text-[10px] font-nanum mt-1 mr-1 decoration-solid underline"
+          >
             로그아웃
           </button>
         </div>

--- a/src/pages/MyProfile.jsx
+++ b/src/pages/MyProfile.jsx
@@ -3,8 +3,11 @@ import { Button } from '@/components/button/Button';
 import { useNavigate } from 'react-router-dom';
 import { useState } from 'react';
 import { useEffect } from 'react';
+import useAuthStore from '@/store/auth';
 
 function MyProfile() {
+  const user = useAuthStore((state) => state.user);
+  console.log(user);
   const navigate = useNavigate();
   const handleNavigate = () => {
     navigate('/myfridge');
@@ -20,14 +23,14 @@ function MyProfile() {
         // PocketBase 에서 닉네임 가져오기
         const nameResponse = await pb
           .collection('users')
-          .getList(1, 10, { filter: `username = "qwer1212"` });
+          .getList(1, 10, { filter: `id = "${user}"` });
         setProfileName(nameResponse.items[0].name);
         console.log(profileName);
 
         // PocketBase 에서 프로필 이미지 가져오기
         const imageResponse = await pb
           .collection('users')
-          .getList(1, 10, { filter: `username = "qwer1212"` });
+          .getList(1, 10, { filter: `id = "${user}"` });
         setFileName(imageResponse.items[0].avatar);
         setProfileImage(
           pb.files.getUrl(imageResponse.items[0], fileName, {
@@ -40,7 +43,7 @@ function MyProfile() {
       }
     };
     handleProfile();
-  }, [profileName, profileImage, fileName]);
+  }, [profileName, profileImage, fileName, user]);
 
   return (
     <>

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -4,6 +4,7 @@ import debounce from '@/utils/debounce';
 import { Link, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/button/Button';
 import useAuthStore from '@/store/auth';
+import { useEffect } from 'react';
 
 function SignIn() {
   const navigate = useNavigate();
@@ -11,20 +12,10 @@ function SignIn() {
     id: '',
     password: '',
   });
+  const [failAlert, setFailAlert] = useState(false);
+  const [isError, setIsError] = useState(false);
 
   const { signIn } = useAuthStore();
-
-  const handleSignIn = async (e) => {
-    e.preventDefault();
-    const { id, password } = formState;
-
-    try {
-      signIn(id, password).then(() => navigate('/home'));
-    } catch (error) {
-      console.error(error);
-      setFormState({ id: '', password: '' });
-    }
-  };
 
   const handleInput = debounce((e) => {
     const { name, value } = e.target;
@@ -33,6 +24,25 @@ function SignIn() {
       [name]: value,
     });
   }, 400);
+
+  const handleSignIn = async (e) => {
+    e.preventDefault();
+    const { id, password } = formState;
+
+    try {
+      signIn(id, password).then(() => navigate('/home'));
+    } catch (error) {
+      console.error('로그인 실패');
+    } finally {
+      setIsError(true);
+    }
+  };
+
+  useEffect(() => {
+    if (isError) {
+      setFailAlert('아이디 또는 비밀번호가 일치하지 않습니다.');
+    }
+  }, [isError]);
 
   return (
     <>
@@ -73,12 +83,15 @@ function SignIn() {
               />
             </label>
             <Button type="submit">로그인</Button>
+            <p className="-text--fridge-red font-nanum text-xs mt-2 text-center">
+              {failAlert}
+            </p>
           </form>
         </div>
 
         <Link
           to="/signup"
-          className="w-full max-w-[820px] -text--fridge-black text-[10px] font-nanum decoration-solid flex items-end mt-2 px-[20px] underline justify-end"
+          className="w-full max-w-[820px] -text--fridge-black text-xs font-nanum decoration-solid flex items-end mt-2 mx-[20px] underline justify-end"
         >
           아직 회원이 아니신가요?
         </Link>

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -39,7 +39,6 @@ function SignIn() {
   useEffect(() => {
     if (isValid) {
       navigate('/home');
-      // setFormState({ id: '', password: '' });
     }
   }, [isValid, navigate]);
 

--- a/src/pages/SignIn.jsx
+++ b/src/pages/SignIn.jsx
@@ -5,6 +5,8 @@ import { Link, useNavigate } from 'react-router-dom';
 import { Button } from '@/components/button/Button';
 import useAuthStore from '@/store/auth';
 import { useEffect } from 'react';
+import { ToastContainer, toast } from 'react-toastify';
+import 'react-toastify/dist/ReactToastify.css';
 
 function SignIn() {
   const navigate = useNavigate();
@@ -12,10 +14,8 @@ function SignIn() {
     id: '',
     password: '',
   });
-  const [failAlert, setFailAlert] = useState(false);
-  const [isError, setIsError] = useState(false);
 
-  const { signIn } = useAuthStore();
+  const { isValid, signIn } = useAuthStore();
 
   const handleInput = debounce((e) => {
     const { name, value } = e.target;
@@ -30,23 +30,35 @@ function SignIn() {
     const { id, password } = formState;
 
     try {
-      signIn(id, password).then(() => navigate('/home'));
+      await signIn(id, password);
     } catch (error) {
-      console.error('로그인 실패');
-    } finally {
-      setIsError(true);
+      toast.error('아이디 또는 비밀번호가 일치하지 않습니다.');
     }
   };
 
   useEffect(() => {
-    if (isError) {
-      setFailAlert('아이디 또는 비밀번호가 일치하지 않습니다.');
+    if (isValid) {
+      navigate('/home');
+      // setFormState({ id: '', password: '' });
     }
-  }, [isError]);
+  }, [isValid, navigate]);
 
   return (
     <>
       <div className="loginContainer m-auto flex justify-center flex-wrap flex-col -bg--fridge-secondary w-screen">
+        <ToastContainer
+          position="top-center"
+          autoClose={3000}
+          limit={1}
+          hideProgressBar={false}
+          newestOnTop={false}
+          closeOnClick
+          rtl={false}
+          pauseOnFocusLoss
+          draggable
+          pauseOnHover
+          theme="colored"
+        />
         <div className="pt-[100px] pb-[15px] h-[188px]">
           <h1 className="text-[35px] -text--fridge-black font-dohyeon font-normal text-center">
             로그인
@@ -83,15 +95,12 @@ function SignIn() {
               />
             </label>
             <Button type="submit">로그인</Button>
-            <p className="-text--fridge-red font-nanum text-xs mt-2 text-center">
-              {failAlert}
-            </p>
           </form>
         </div>
 
         <Link
           to="/signup"
-          className="w-full max-w-[820px] -text--fridge-black text-xs font-nanum decoration-solid flex items-end mt-2 mx-[20px] underline justify-end"
+          className="w-full max-w-[820px] -text--fridge-black text-xs font-nanum decoration-solid flex items-end mt-2 px-[20px] underline justify-end"
         >
           아직 회원이 아니신가요?
         </Link>

--- a/src/pages/Start.jsx
+++ b/src/pages/Start.jsx
@@ -26,7 +26,7 @@ function Start() {
             </div>
           </div>
           <div className="bottomFridge  -bg--fridge-white rounded-b-[15px] min-h-[244px] relative">
-            <div className="FridgeHandle w-[14px] h-[52px] -bg--fridge-gray rounded-[15px] absolute top-[20px] right-[24px]"></div>
+            <button className="FridgeHandle w-[14px] h-[52px] -bg--fridge-gray rounded-[15px] absolute top-[20px] right-[24px]"></button>
           </div>
 
           <p className="-text--fridge-nav-gray font-dohyeon text-[15px] block mt-[9px] mx-auto">

--- a/src/store/auth.js
+++ b/src/store/auth.js
@@ -28,7 +28,7 @@ const authStore = (set) => ({
     set((state) => ({
       ...state,
       isValid,
-      id: model.id,
+      user: model.id,
       token,
     }));
 


### PR DESCRIPTION
## 1. SignIn 페이지
- 로그인 실패 시, toast 로 실패 알림 추가

## 2. MyProfile 페이지
- UI 마크업 및 스타일링
- 버튼 별 페이지 이동 기능 구현
- 로그인 한 아이디에 따라 MyProfile 의 프로필 이미지, 닉네임 변경 되는 PocketBase 통신 기능 구현
- 로그아웃 시 toast 알람 3초 이후 페이지 이동하는 기능 구현

## 3. 기타
- CategoryButton 컴포넌트에 pocketbase 통신 기능 추가
- Start 페이지 접근성 이슈 해결 (버튼 추가)

---
![logIn_logOut](https://github.com/FRONTENDSCHOOL6/5lemental-final/assets/134567470/f173134e-c0ab-4ecd-a4cf-a98183f983df)
