### PR TITLE
[modify] Heading 컴포넌트 fixed 로 조정

### DIFF
--- a/src/components/Heading.jsx
+++ b/src/components/Heading.jsx
@@ -77,10 +77,10 @@ function Heading() {
 
   return (
     <>
-      <div className="wrapper max-w-[820px] m-auto relative pt-[20px] flex justify-center items-center">
-        <div className="container flex justify-center items-center">
+      <header className="w-screen flex justify-center items-center fixed top-0 left-0 -bg--fridge-white pb-4 z-[1000]">
+        <div className="wrapper max-w-[820px] w-full m-auto pt-[20px] relative flex justify-center items-center">
           <button
-            className="w-[20px] h-[20px] absolute left-[20px] top-[25px]"
+            className="w-[20px] h-[20px] absolute left-[20px] top-[20px]"
             onClick={() => navigate(-1)}
           >
             <img className="w-full h-full" src={arrowLeft} alt="뒤로가기" />
@@ -89,7 +89,7 @@ function Heading() {
             {title}
           </h1>
         </div>
-      </div>
+      </header>
     </>
   );
 }

--- a/src/layout/RootLayout.jsx
+++ b/src/layout/RootLayout.jsx
@@ -1,20 +1,26 @@
 import NavBar from '@/components/navBar/NavBar';
 import Heading from '@/components/Heading';
 import { Outlet, useLocation } from 'react-router-dom';
+import { useEffect } from 'react';
+import { useState } from 'react';
 
 function RootLayout() {
   const { pathname } = useLocation();
 
-  let isHiddenPadding = null;
+  const [isHiddenPadding, setIsHiddenPadding] = useState(false);
 
-  if ( pathname === '/' || pathname === '/signin' || pathname === 'signup') {
-    isHiddenPadding = null;
-  }
+  useEffect(
+    () =>
+      pathname === '/' || pathname === '/signin' || pathname === 'signup'
+        ? setIsHiddenPadding(true)
+        : setIsHiddenPadding(false),
+    [pathname]
+  );
 
   return (
     <>
       <Heading />
-      <main className={!isHiddenPadding ? 'pb-20' : isHiddenPadding}>
+      <main className={!isHiddenPadding ? 'pt-12 pb-20' : isHiddenPadding}>
         <Outlet />
       </main>
       <NavBar />
@@ -22,4 +28,4 @@ function RootLayout() {
   );
 }
 
-export default RootLayout
+export default RootLayout;


### PR DESCRIPTION
Heading 컴포넌트가 스크롤이 생길 시, 위로 올라가는 이슈가 있어 fixed 로 스타일링 조정하였습니다.
Heading 컴포넌트에 전체 div 태그를 header 태그로 교체하였습니다.

- 추가 수정 필요: MenuList 페이지 위 카테고리 선택 버튼 잘리는 이슈 있음

---

![Sep-23-2023 17-58-06](https://github.com/FRONTENDSCHOOL6/make-my-fridge-empty/assets/134567470/6bdfebaf-4f08-4662-9037-651dfac8c0ba)
