### PR TITLE
[add] Search 페이지에 useLocation 훅 추가

### DIFF
--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -4,10 +4,12 @@ import SearchInput from '@/components/SearchInput';
 import useSearchLogStore from '@/store/search';
 import { useState } from 'react';
 import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
 
 function Search() {
   const searchList = useSearchLogStore((state) => state.searchList);
   const [cooksList, setCooksList] = useState([]);
+  const location = useLocation();
 
   useEffect(
     () =>
@@ -23,11 +25,11 @@ function Search() {
           console.log(error);
         }
       },
-    [searchList]
+    [searchList, location]
   );
 
   return (
-    <div className="px-5 w-full max-w-[820px] m-auto mt-9">
+    <div className="px-5 w-full max-w-[820px] m-auto">
       <SearchInput searchType="menu"></SearchInput>
       {searchList.length > 0 ? (
         searchList.map((searchItem) =>


### PR DESCRIPTION
타 페이지에서 search로 이동 시, useEffect 내부 함수 동작하도록 하기 위한 useLocation 훅을 추가하여, url 변경 시 useEffect 내부 함수가 바로 동작하도록 하여 배포 환경의 검색 버그 해결하고자 함.