### PR TITLE
[add] navigate 전역상태 추가, 페이지 이동 시 search 페이지에서 상태 변경

### DIFF
--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -4,12 +4,15 @@ import SearchInput from '@/components/SearchInput';
 import useSearchLogStore from '@/store/search';
 import { useState } from 'react';
 import { useEffect } from 'react';
-import { useLocation } from 'react-router-dom';
 
 function Search() {
-  const searchList = useSearchLogStore((state) => state.searchList);
+  const { searchList, isNavigated, setIsNavigated } = useSearchLogStore();
   const [cooksList, setCooksList] = useState([]);
-  const location = useLocation();
+
+  if (isNavigated) {
+    setIsNavigated(false);
+    console.log(isNavigated);
+  }
 
   useEffect(
     () =>
@@ -25,7 +28,7 @@ function Search() {
           console.log(error);
         }
       },
-    [searchList, location]
+    [searchList, isNavigated]
   );
 
   return (

--- a/src/store/search.js
+++ b/src/store/search.js
@@ -2,6 +2,7 @@ import { create } from 'zustand';
 
 const initialSearchLogState = {
   searchList: [],
+  isNavigated: true,
 };
 
 const useSearchLogStore = create((set) => ({
@@ -13,6 +14,14 @@ const useSearchLogStore = create((set) => ({
       searchList: searchItem,
     }));
     return searchItem;
+  },
+
+  setIsNavigated: (status) => {
+    set((state) => ({
+      ...state,
+      isNavigated: status,
+    }));
+    return status;
   },
 }));
 


### PR DESCRIPTION
home 화면에서 search 페이지로 이동 시, 특정 조건이 추가되지 않으면 search 페이지 내 useEffect 함수가 작동하지 않아 검색 결과를 볼 수 없는 것을 원인으로 파악하였습니다.
따라서 search.js 에 navigate 상태를 관리하기 위한 전역상태를 추가하고, search 페이지 접근 시 해당 상태가 변경되도록 하여, useEffect 내부의 함수가 작동하도록 수정하였습니다.